### PR TITLE
HS-11416-2/Fixes descriptive_statistics for rails 5 by removing sum

### DIFF
--- a/descriptive_statistics.gemspec
+++ b/descriptive_statistics.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'descriptive_statistics'
-  s.version     = '2.5.1'
+  s.version     = '3.0.0'
   s.homepage    = 'https://github.com/thirtysixthspan/descriptive_statistics'
   s.summary     = 'Descriptive Statistics'
   s.description = 'Adds descriptive statistics methods to Enumerable module for use on collections or Numeric data'

--- a/lib/descriptive_statistics/descriptive_statistics.rb
+++ b/lib/descriptive_statistics/descriptive_statistics.rb
@@ -1,7 +1,6 @@
 module DescriptiveStatistics
   def descriptive_statistics(&block)
     return { :number => self.number(&block),
-             :sum => self.sum(&block),
              :variance => self.variance(&block),
              :standard_deviation => self.standard_deviation(&block),
              :min => self.min(&block),

--- a/lib/descriptive_statistics/safe.rb
+++ b/lib/descriptive_statistics/safe.rb
@@ -1,6 +1,5 @@
 require "descriptive_statistics/support/convert"
 require 'descriptive_statistics/number.rb'
-require 'descriptive_statistics/sum.rb'
 require 'descriptive_statistics/mean.rb'
 require 'descriptive_statistics/median.rb'
 require 'descriptive_statistics/mode.rb'

--- a/spec/monkeypatch/array_spec.rb
+++ b/spec/monkeypatch/array_spec.rb
@@ -17,10 +17,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(11.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(54.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(4.909090909090909)
     end

--- a/spec/monkeypatch/empty_collection_spec.rb
+++ b/spec/monkeypatch/empty_collection_spec.rb
@@ -15,10 +15,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(0.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(nil)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(nil)
     end
@@ -73,10 +69,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(0.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(0.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(0.0)
     end
@@ -117,61 +109,6 @@ describe "DescriptiveStatistics" do
 
   end
 
-  context "with a default of 0.0 only for sum" do
-
-    before do
-      DescriptiveStatistics.empty_collection_default_value = nil
-      DescriptiveStatistics.sum_empty_collection_default_value = 0.0
-    end
-
-    it "calculates the number" do
-      expect(subject.number).to eql(0.0)
-    end
-
-    it "calculates the sum" do
-      expect(subject.sum).to eql(0.0)
-    end
-
-    it "calculates the mean" do
-      expect(subject.mean).to eql(nil)
-    end
-
-    it "calculates the median" do
-      expect(subject.median).to eql(nil)
-    end
-
-    it "calculates the variance" do
-      expect(subject.variance).to eql(nil)
-    end
-
-    it "calculates the standard_deviation" do
-      expect(subject.standard_deviation).to eql(nil)
-    end
-
-    it "calculates the percentile" do
-      expect(subject.percentile(30)).to eql(nil)
-      expect(subject.percentile(50)).to eql(nil)
-      expect(subject.percentile(70)).to eql(nil)
-    end
-
-    it "calculates the same value for the 50th percentile and median" do
-      expect(subject.percentile(50)).to eql(subject.median)
-    end
-
-    it "does not calculate a mode" do
-      expect(subject.mode).to eql(nil)
-    end
-
-    it "calculates the range" do
-      expect(subject.range).to eql(nil)
-    end
-
-    it "calculates the percentile rank" do
-      expect(subject.percentile_rank(8)).to eql(nil)
-    end
-
-  end
-
   context "with a default of 0.0 only for variance" do
 
     before do
@@ -181,10 +118,6 @@ describe "DescriptiveStatistics" do
 
     it "calculates the number" do
       expect(subject.number).to eql(0.0)
-    end
-
-    it "calculates the sum" do
-      expect(subject.sum).to eql(nil)
     end
 
     it "calculates the mean" do

--- a/spec/monkeypatch/hash_spec.rb
+++ b/spec/monkeypatch/hash_spec.rb
@@ -17,10 +17,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(11.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(54.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(4.909090909090909)
     end

--- a/spec/monkeypatch/object_spec.rb
+++ b/spec/monkeypatch/object_spec.rb
@@ -21,10 +21,6 @@ describe "DescriptiveStatistics" do
         expect(subject.number(&:price)).to eql(4.0)
       end
 
-      it "calculates the sum" do
-        expect(subject.sum(&:price)).to eql(13.8)
-      end
-
       it "calculates the mean" do
         expect(subject.mean(&:price)).to eql(3.45)
       end
@@ -69,10 +65,6 @@ describe "DescriptiveStatistics" do
 
       it "calculates the number" do
         expect(subject.number{|v| v.price * v.quantity}).to eql(4.0)
-      end
-
-      it "calculates the sum" do
-        expect(subject.sum{|v| v.price * v.quantity}).to eql(78.7)
       end
 
       it "calculates the mean" do

--- a/spec/monkeypatch/set_spec.rb
+++ b/spec/monkeypatch/set_spec.rb
@@ -17,10 +17,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(7.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(34.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(4.857142857142857)
     end

--- a/spec/monkeypatch/single_value_spec.rb
+++ b/spec/monkeypatch/single_value_spec.rb
@@ -11,10 +11,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(1.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(2.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(2.0)
     end

--- a/spec/safe/class_method_spec.rb
+++ b/spec/safe/class_method_spec.rb
@@ -12,10 +12,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number(data)).to eql(11.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum(data)).to eql(54.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean(data)).to eql(4.909090909090909)
     end

--- a/spec/safe/extend_spec.rb
+++ b/spec/safe/extend_spec.rb
@@ -22,10 +22,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(11.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(54.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(4.909090909090909)
     end

--- a/spec/safe/stats_spec.rb
+++ b/spec/safe/stats_spec.rb
@@ -11,10 +11,6 @@ describe "DescriptiveStatistics" do
       expect(subject.number).to eql(11.0)
     end
 
-    it "calculates the sum" do
-      expect(subject.sum).to eql(54.0)
-    end
-
     it "calculates the mean" do
       expect(subject.mean).to eql(4.909090909090909)
     end


### PR DESCRIPTION
- Story: [HS-11416](https://hoopla.atlassian.net/browse/HS-11416)

- Changes:
    - Removes sum method from the gem
    - Removes tests relating to sum

- Notes:
    - Sum tests could still pass with the new ActiveSupport gem, but the return value of the new method is integer, while descriptive_statistics's sum always returns a float. This does not cause problems in insight_service.